### PR TITLE
Upgrade to Orleans 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # <img src="img/CSharp-Toolkit-Icon.png" alt="Backend Toolkit" width="64px" />Orleans.Multitenant
-Secure, flexible tenant separation for Microsoft Orleans 7
+Secure, flexible tenant separation for Microsoft Orleans 8
 
 > [![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Orleans.Multitenant?color=gold&label=NuGet:%20Orleans.Multitenant&style=plastic)](https://www.nuget.org/packages/Orleans.Multitenant)<br />
 > (install in silo client and grain implementation projects)
 
 ## Summary
-[Microsoft Orleans 7](https://github.com/dotnet/orleans/releases/tag/v7.0.0) is a great technology for building distributed, cloud-native applications. It was designed to reduce the complexity of building this type of applications for C# developers.
+[Microsoft Orleans 8](https://github.com/dotnet/orleans/releases/tag/v8.0.0) is a great technology for building distributed, cloud-native applications. It was designed to reduce the complexity of building this type of applications for C# developers.
 
 However, creating multi tenant applications with Orleans out of the box requires careful design, complex coding and significant testing to prevent unintentional leakage of communication or stored data across tenants. Orleans.Multitenant adds this capability to Orleans for free, as an uncomplicated, flexible and extensible API that lets developers:
 

--- a/src/Example/Apis/Apis.csproj
+++ b/src/Example/Apis/Apis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisLevel>preview-All</AnalysisLevel>
@@ -16,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
-    <PackageReference Include="Orleans.Multitenant" Version="1.1.4" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Orleans.Multitenant" Version="2.0.0-preview.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/src/Example/Apis/Foundation/Program.cs
+++ b/src/Example/Apis/Foundation/Program.cs
@@ -32,7 +32,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options => {
     options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}.xml"));
-    options.SwaggerDoc("v1", new OpenApiInfo { Title = "Example Orleans 7 Multitenant API", Version = "v1" });
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "Example Orleans 8 Multitenant API", Version = "v1" });
     options.OperationFilter<TenantHeader.AddAsOpenApiParameter>();
 });
 

--- a/src/Example/Contracts/Contracts.csproj
+++ b/src/Example/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
+		<PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/Example/Services.Tenant/Services.Tenant.csproj
+++ b/src/Example/Services.Tenant/Services.Tenant.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
-    <PackageReference Include="Orleans.Multitenant" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Orleans.Multitenant" Version="2.0.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Multitenant/Internal/Extensions.cs
+++ b/src/Orleans.Multitenant/Internal/Extensions.cs
@@ -22,13 +22,13 @@ static class SiloBuilderExtensions
 
         if (string.Equals(name, ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, StringComparison.Ordinal))
         {
-            services.TryAddSingleton<IGrainStorage>(sp => sp.GetServiceByName<MultitenantStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
-            services.TryAddSingleton(sp => sp.GetServiceByName<ITenantGrainStorageFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+            services.TryAddSingleton<IGrainStorage>(sp => sp.GetKeyedService<MultitenantStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
+            services.TryAddSingleton(sp => sp.GetKeyedService<ITenantGrainStorageFactory>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
         }
-        return services.AddSingletonNamedService(name, MultitenantStorageFactory.Create)
-                       .AddSingletonNamedService<IGrainStorage>(name, (s, n) => s.GetRequiredServiceByName<MultitenantStorage>(n))
-                       .AddSingletonNamedService(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n))
-                       .AddSingletonNamedService(name, factory);
+        return services.AddKeyedSingleton(name, (s, _) => MultitenantStorageFactory.Create(s, name))
+                       .AddKeyedSingleton<IGrainStorage>(name, (s, n) => s.GetRequiredKeyedService<MultitenantStorage>(n))
+                       .AddKeyedSingleton(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredKeyedService<IGrainStorage>(n))
+                       .AddKeyedSingleton(name, (s, _) => factory(s, name));
     }
 }
 

--- a/src/Orleans.Multitenant/Internal/StorageProvider.cs
+++ b/src/Orleans.Multitenant/Internal/StorageProvider.cs
@@ -30,7 +30,7 @@ sealed class MultitenantStorage : IGrainStorage, ILifecycleParticipant<ISiloLife
         IServiceProvider serviceProvider,
         ILogger<MultitenantStorage> logger)
      => (this.name, this.options, tenantGrainStorageFactory, this.logger) = 
-        (name, options, serviceProvider.GetRequiredServiceByName<ITenantGrainStorageFactory>(name), logger);
+        (name, options, serviceProvider.GetRequiredKeyedService<ITenantGrainStorageFactory>(name), logger);
 
     public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
     {

--- a/src/Orleans.Multitenant/Internal/TenantGrainStorageFactory.cs
+++ b/src/Orleans.Multitenant/Internal/TenantGrainStorageFactory.cs
@@ -51,7 +51,7 @@ sealed class TenantGrainStorageFactory<TGrainStorage, TGrainStorageOptions, TGra
         configureTenantOptions?.Invoke(options, tenantId);
 
         if (options is IStorageProviderSerializerOptions serializerOptions && serializerOptions.GrainStorageSerializer == default)
-            serializerOptions.GrainStorageSerializer = services.GetServiceByName<IGrainStorageSerializer>(name) ?? services.GetRequiredService<IGrainStorageSerializer>();
+            serializerOptions.GrainStorageSerializer = services.GetKeyedService<IGrainStorageSerializer>(name) ?? services.GetRequiredService<IGrainStorageSerializer>();
 
         var validator = ActivatorUtilities.CreateInstance<TGrainStorageOptionsValidator>(services, options, tenantProviderName);
         validator.ValidateConfiguration();

--- a/src/Orleans.Multitenant/Orleans.Multitenant.csproj
+++ b/src/Orleans.Multitenant/Orleans.Multitenant.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,9 +13,9 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <PackageId>Orleans.Multitenant</PackageId>
-        <PackageVersion>1.1.4</PackageVersion>
+        <PackageVersion>2.0.0-preview.1</PackageVersion>
         <Title>Orleans Multitenant</Title>
-        <Description>Secure, flexible tenant separation for Microsoft Orleans 7</Description>
+        <Description>Secure, flexible tenant separation for Microsoft Orleans 8</Description>
         <Authors>VincentH.NET;Applicita</Authors>
         <Company>Applicita</Company>
         <Copyright>Copyright © Applicita</Copyright>
@@ -25,7 +25,7 @@
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <PackageReleaseNotes>See source repository for release notes</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/Applicita/Orleans.Multitenant</RepositoryUrl>
-        <PackageTags>multitenant;multi-tenant;tenant;tenant separation;separation;Orleans;Orleans 7;Microsoft Orleans;Applicita</PackageTags>
+        <PackageTags>multitenant;multi-tenant;tenant;tenant separation;separation;Orleans;Orleans 8;Microsoft Orleans;Applicita</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <!-- Enable Source Link -->
@@ -41,9 +41,9 @@
     </ItemGroup>
 
     <ItemGroup>
-		<PackageReference Include="Microsoft.Orleans.Runtime" Version="7.1.2" />
-		<PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
-		<PackageReference Include="Microsoft.Orleans.Streaming" Version="7.1.2" />
+		<PackageReference Include="Microsoft.Orleans.Runtime" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Orleans.Streaming" Version="8.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/src/Orleans.Multitenant/Readme.md
+++ b/src/Orleans.Multitenant/Readme.md
@@ -1,5 +1,5 @@
-﻿Secure, flexible tenant separation for [Microsoft Orleans 7](https://github.com/dotnet/orleans/releases/tag/v7.0.0)
+﻿Secure, flexible tenant separation for [Microsoft Orleans 8](https://github.com/dotnet/orleans/releases/tag/v8.0.0)
 
 Docs: see the [repo readme](https://github.com/Applicita/Orleans.Multitenant#readme) and the inline C# documentation. All public Orleans.Multitenant API's come with full inline documentation.
 
-[Release Notes](https://github.com/Applicita/Orleans.Multitenant/releases/tag/1-1-4)
+[Release Notes](https://github.com/Applicita/Orleans.Multitenant/releases/tag/2-0-0)

--- a/src/Tests/Orleans.Multitenant.Tests.csproj
+++ b/src/Tests/Orleans.Multitenant.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Happy user of your Orleans Multitenant package here.

Recently tried to upgrade Orleans from 7 to 8 but unfortunately the latest version (1.1.4) is not compatible with Orleans 8 because it relies on the Orleans specific DI extension methods for keyed/named services in the Orleans Core assembly; which are no longer there since Orleans 8 now uses the .NET 8 native keyed service DI methods instead.

I hope you don't mind me making this contribution to see if we can introduce support for Orleans 8. Feel free to do with this as you wish of course.

Changes:
- Target framework upgraded from net7 to net8;
- Orleans version upgrade from 7 to 8.

Build and tests of the main projects pass. The example projects rely on a yet-to-be-released preview version with these changes.

Notes/questions:
- Orleans 8 ships with a new analyzer to detect/warn for missing 'Alias' attributes on custom types. Not sure if/you want to add these, but I left them out for now. This will or might trigger new build warnings. (Links for context: https://github.com/dotnet/orleans/issues/8345, https://github.com/dotnet/orleans/pull/8643)
- I believe I'm only able to make a PR to your main branch. However, should you accept the proposed changes, maybe it would be better to target a orleans8-preview branch instead to be able to release a preview version?
- Would you consider aligning the version numbers with those of Orleans (which itself now aligns with major version numbers from .NET)? This way it might be easier for consumers of the library to understand which version supports which target framework.