### PR TITLE
Feature: custom storage provider parameters

### DIFF
--- a/src/Example/Apis/Apis.csproj
+++ b/src/Example/Apis/Apis.csproj
@@ -17,12 +17,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="8.1.0" />
     <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="8.1.0" />
     <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="8.1.0" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.1.0" />
-    <PackageReference Include="Orleans.Multitenant" Version="2.1.0" />
+    <PackageReference Include="Orleans.Multitenant" Version="2.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Example/Apis/Apis.csproj
+++ b/src/Example/Apis/Apis.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="8.1.0" />
     <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="8.1.0" />
     <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="8.1.0" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.1.0" />

--- a/src/Example/Apis/Apis.csproj
+++ b/src/Example/Apis/Apis.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Orleans.Multitenant" Version="2.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Example/Apis/Foundation/Program.cs
+++ b/src/Example/Apis/Foundation/Program.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.OpenApi.Models;
-using Azure.Data.Tables;
+﻿using Azure.Data.Tables;
 using Orleans.Configuration;
+using Microsoft.OpenApi.Models;
 using Orleans.Multitenant;
 using Orleans.Storage;
 using Orleans4Multitenant.Apis;
@@ -12,19 +12,19 @@ builder.Host.UseOrleans((_, silo) => silo
     .UseLocalhostClustering()
     .AddMultitenantCommunicationSeparation()
     .AddMultitenantGrainStorageAsDefault<AzureTableGrainStorage, AzureTableStorageOptions, AzureTableGrainStorageOptionsValidator>(
-            (silo, name) => silo.AddAzureTableGrainStorage(name, options =>
-                options.TableServiceClient = new TableServiceClient(tableStorageConnectionString)),
-            // Called during silo startup, to ensure that any common dependencies
-            // needed for tenant-specific provider instances are initialized
+        (silo, name) => silo.AddAzureTableGrainStorage(name, options =>
+            options.TableServiceClient = new TableServiceClient(tableStorageConnectionString)),
+        // Called during silo startup, to ensure that any common dependencies
+        // needed for tenant-specific provider instances are initialized
 
-            configureTenantOptions: (options, tenantId) =>
-            {
-                options.TableServiceClient = new TableServiceClient(tableStorageConnectionString);
-                options.TableName = $"OrleansGrainState{tenantId}";
-            }   // Called on the first grain state access for a tenant in a silo,
-                // to initialize the options for the tenant-specific provider instance
-                // just before it is instantiated
-        )
+        configureTenantOptions: (options, tenantId) =>
+        {
+            options.TableServiceClient = new TableServiceClient(tableStorageConnectionString);
+            options.TableName = $"OrleansGrainState{tenantId}";
+        }   // Called on the first grain state access for a tenant in a silo,
+            // to initialize the options for the tenant-specific provider instance
+            // just before it is instantiated
+    )
 );
 
 // Add services to the container.

--- a/src/Example/Services.Tenant/Services.Tenant.csproj
+++ b/src/Example/Services.Tenant/Services.Tenant.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.1.0" />
-    <PackageReference Include="Orleans.Multitenant" Version="2.1.0" />
+    <PackageReference Include="Orleans.Multitenant" Version="2.2.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Multitenant/Extensions.cs
+++ b/src/Orleans.Multitenant/Extensions.cs
@@ -39,12 +39,14 @@ public static class SiloBuilderExtensions
     /// This storage provider instance will not be used to store state - it is only called at silo initialization, to ensure that any shared dependencies needed by the tenant-specific storage provider instances are initialized
     /// </param>
     /// <param name="configureTenantOptions">Action to configure the supplied <typeparamref name="TGrainStorageOptions"/> based on the supplied tenant ID (e.g. use the tenant ID in a storage table name to realize separate storage per tenant)</param>
+    /// <param name="getProviderParameters">Optional factory to transform or add constructor parameters for tenant grain storage providers; for details see <see cref="GrainStorageProviderParametersFactory{TGrainStorageOptions}"/><br />When omitted, only <typeparamref name="TGrainStorageOptions"/> is passed in</param>
     /// <param name="configureOptions">Action to configure the <see cref="MultitenantStorageOptions"/></param>
     /// <returns>The same instance of the <see cref="ISiloBuilder"/> for chaining</returns>
     public static ISiloBuilder AddMultitenantGrainStorageAsDefault<TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator>(
         this ISiloBuilder builder,
         Func<ISiloBuilder, string, ISiloBuilder> addStorageProvider,
         Action<TGrainStorageOptions, string>? configureTenantOptions = null,
+        GrainStorageProviderParametersFactory<TGrainStorageOptions>? getProviderParameters = null,
         Action<OptionsBuilder<MultitenantStorageOptions>>? configureOptions = null)
         where TGrainStorage : IGrainStorage
         where TGrainStorageOptions : class, new()
@@ -53,6 +55,7 @@ public static class SiloBuilderExtensions
         ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME,
         (services, name) => { _ = addStorageProvider(builder, name); return services; },
         configureTenantOptions,
+        getProviderParameters,
         configureOptions);
 
     /// <summary>
@@ -70,6 +73,7 @@ public static class SiloBuilderExtensions
     /// This storage provider instance will not be used to store state - it is only called at silo initialization, to ensure that any shared dependencies needed by the tenant-specific storage provider instances are initialized
     /// </param>
     /// <param name="configureTenantOptions">Action to configure the supplied <typeparamref name="TGrainStorageOptions"/> based on the supplied tenant ID (e.g. use the tenant ID in a storage table name to realize separate storage per tenant)</param>
+    /// <param name="getProviderParameters">Optional factory to transform or add constructor parameters for tenant grain storage providers; for details see <see cref="GrainStorageProviderParametersFactory{TGrainStorageOptions}"/><br />When omitted, only <typeparamref name="TGrainStorageOptions"/> is passed in</param>
     /// <param name="configureOptions">Action to configure the <see cref="MultitenantStorageOptions"/></param>
     /// <returns>The same instance of the <see cref="ISiloBuilder"/> for chaining</returns>
     public static ISiloBuilder AddMultitenantGrainStorage<TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator>(
@@ -77,6 +81,7 @@ public static class SiloBuilderExtensions
         string name,
         Func<ISiloBuilder, string, ISiloBuilder> addStorageProvider,
         Action<TGrainStorageOptions, string>? configureTenantOptions = null,
+        GrainStorageProviderParametersFactory<TGrainStorageOptions>? getProviderParameters = null,
         Action<OptionsBuilder<MultitenantStorageOptions>>? configureOptions = null)
         where TGrainStorage : IGrainStorage
         where TGrainStorageOptions : class, new()
@@ -85,6 +90,7 @@ public static class SiloBuilderExtensions
         name,
         (sevices, name) => { _ = addStorageProvider(builder, name); return sevices; },
         configureTenantOptions,
+        getProviderParameters,
         configureOptions));
 
     /// <summary>Configure silo to use a specific stream provider type as a named stream provider, with tenant separation</summary>
@@ -121,12 +127,14 @@ public static class ServiceCollectionExtensions
     /// This storage provider instance will not be used to store state - it is only called at silo initialization, to ensure that any shared dependencies needed by the tenant-specific storage provider instances are initialized
     /// </param>
     /// <param name="configureTenantOptions">Action to configure the supplied <typeparamref name="TGrainStorageOptions"/> based on the supplied tenant ID (e.g. use the tenant ID in a storage table name to realize separate storage per tenant)</param>
+    /// <param name="getProviderParameters">Optional factory to transform or add constructor parameters for tenant grain storage providers; for details see <see cref="GrainStorageProviderParametersFactory{TGrainStorageOptions}"/><br />When omitted, only <typeparamref name="TGrainStorageOptions"/> is passed in</param>
     /// <param name="configureOptions">Action to configure the <see cref="MultitenantStorageOptions"/></param>
     /// <returns>The same instance of the <see cref="IServiceCollection"/> for chaining</returns>
     public static IServiceCollection AddMultitenantGrainStorageAsDefault<TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator>(
         this IServiceCollection services,
         Func<IServiceCollection, string, IServiceCollection> addStorageProvider,
         Action<TGrainStorageOptions, string>? configureTenantOptions = null,
+        GrainStorageProviderParametersFactory<TGrainStorageOptions>? getProviderParameters = null,
         Action<OptionsBuilder<MultitenantStorageOptions>>? configureOptions = null)
         where TGrainStorage : IGrainStorage
         where TGrainStorageOptions : class, new()
@@ -135,6 +143,7 @@ public static class ServiceCollectionExtensions
         ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME,
         addStorageProvider,
         configureTenantOptions,
+        getProviderParameters,
         configureOptions);
 
     /// <summary>
@@ -152,6 +161,7 @@ public static class ServiceCollectionExtensions
     /// This storage provider instance will not be used to store state - it is only called at silo initialization, to ensure that any shared dependencies needed by the tenant-specific storage provider instances are initialized
     /// </param>
     /// <param name="configureTenantOptions">Action to configure the supplied <typeparamref name="TGrainStorageOptions"/> based on the supplied tenant ID (e.g. use the tenant ID in a storage table name to realize separate storage per tenant)</param>
+    /// <param name="getProviderParameters">Optional factory to transform or add constructor parameters for tenant grain storage providers; for details see <see cref="GrainStorageProviderParametersFactory{TGrainStorageOptions}"/><br />When omitted, only <typeparamref name="TGrainStorageOptions"/> is passed in</param>
     /// <param name="configureOptions">Action to configure the <see cref="MultitenantStorageOptions"/></param>
     /// <returns>The same instance of the <see cref="IServiceCollection"/> for chaining</returns>
     public static IServiceCollection AddMultitenantGrainStorage<TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator>(
@@ -159,6 +169,7 @@ public static class ServiceCollectionExtensions
         string name,
         Func<IServiceCollection, string, IServiceCollection> addStorageProvider,
         Action<TGrainStorageOptions, string>? configureTenantOptions = null,
+        GrainStorageProviderParametersFactory<TGrainStorageOptions>? getProviderParameters = null,
         Action<OptionsBuilder<MultitenantStorageOptions>>? configureOptions = null)
         where TGrainStorage : IGrainStorage
         where TGrainStorageOptions : class, new()
@@ -167,10 +178,28 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(addStorageProvider);
         return addStorageProvider(services, name).AddMultitenantGrainStorage(
                 name,
-                (services, name) => TenantGrainStorageFactoryFactory.Create<TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator>(services, name, configureTenantOptions),
+                (services, name) => TenantGrainStorageFactoryFactory.Create<TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator>(services, name, configureTenantOptions, getProviderParameters),
                 configureOptions);
     }
 }
+
+/// <summary>
+/// Factory delegate, used to create parameters for a tenant grain storage provider constructor.<br /> 
+/// Allows to e.g. transform the options if the provider expects a different type than <typeparamref name="TGrainStorageOptions"/>,<br />
+/// or to retrieve an add extra parameters like <see cref="Configuration.ClusterOptions" />
+/// </summary>
+/// <typeparam name="TGrainStorageOptions">The provider-specific grain storage options type, e.g. Orleans.Storage.MemoryGrainStorageOptions or Orleans.Storage.AzureTableStorageOptions</typeparam>
+/// <param name="services">The silo services</param>
+/// <param name="providerName">The name - without the tenant id - of the provider; can be used to access named provider services that are not tenant specific</param>
+/// <param name="tenantProviderName">The name - including the tenant id - of the tenant provider; can be used to access named provider services that are tenant specific</param>
+/// <param name="options">The options to pass to the provider. Note that configureTenantOptions and options validation have already been executed on this</param>
+/// <returns>The tenant storage provider construction parameters to pass to DI. Don't include <paramref name="tenantProviderName"/> in these; it is added automatically</returns>
+public delegate object[] GrainStorageProviderParametersFactory<in TGrainStorageOptions>(
+    IServiceProvider services,
+    string providerName,
+    string tenantProviderName,
+    TGrainStorageOptions options
+);
 
 public static class GrainExtensions
 {

--- a/src/Orleans.Multitenant/MultitenantStorageOptions.cs
+++ b/src/Orleans.Multitenant/MultitenantStorageOptions.cs
@@ -20,7 +20,7 @@ public sealed class MultitenantStorageOptions
     /// <summary>
     /// When a grain does not belong to a tenant (because the grain was not created via the tenant aware grain factory, so it's tenant id is null) and it's state is stored in a multitenant-enabled storage provider,
     /// the value of <see cref="TenantIdForNullTenant"/> is passed as the tenantId parameter of the configureTenantOptions action that is specified
-    /// in AddMultitenantGrainStorage methods (e.g. <see cref="SiloBuilderExtensions.AddMultitenantGrainStorage{TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator}(Hosting.ISiloBuilder, string, Func{Hosting.ISiloBuilder, string, Hosting.ISiloBuilder}, Action{TGrainStorageOptions, string}?, Action{Microsoft.Extensions.Options.OptionsBuilder{MultitenantStorageOptions}}?)"/>)<br />
+    /// in AddMultitenantGrainStorage methods (e.g. <see cref="SiloBuilderExtensions.AddMultitenantGrainStorage{TGrainStorage, TGrainStorageOptions, TGrainStorageOptionsValidator}(ISiloBuilder, string, Func{ISiloBuilder, string, ISiloBuilder}, Action{TGrainStorageOptions, string}?, GrainStorageProviderParametersFactory{TGrainStorageOptions}?, Action{Microsoft.Extensions.Options.OptionsBuilder{MultitenantStorageOptions}}?)"/>)<br />
     /// This allows to differentiate between an empty string tenant Id and a null tenant Id in multitenant storage 
     /// </summary>
     public string TenantIdForNullTenant { get; set; } = "Null";

--- a/src/Orleans.Multitenant/Orleans.Multitenant.csproj
+++ b/src/Orleans.Multitenant/Orleans.Multitenant.csproj
@@ -13,7 +13,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <PackageId>Orleans.Multitenant</PackageId>
-        <PackageVersion>2.2.7</PackageVersion>
+        <PackageVersion>2.2.8</PackageVersion>
         <Title>Orleans Multitenant</Title>
         <Description>Secure, flexible tenant separation for Microsoft Orleans 8</Description>
         <Authors>VincentH.NET;Applicita</Authors>

--- a/src/Orleans.Multitenant/Orleans.Multitenant.csproj
+++ b/src/Orleans.Multitenant/Orleans.Multitenant.csproj
@@ -13,7 +13,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <PackageId>Orleans.Multitenant</PackageId>
-        <PackageVersion>2.1.0</PackageVersion>
+        <PackageVersion>2.2.7</PackageVersion>
         <Title>Orleans Multitenant</Title>
         <Description>Secure, flexible tenant separation for Microsoft Orleans 8</Description>
         <Authors>VincentH.NET;Applicita</Authors>

--- a/src/Orleans.Multitenant/Readme.md
+++ b/src/Orleans.Multitenant/Readme.md
@@ -2,4 +2,4 @@
 
 Docs: see the [repo readme](https://github.com/Applicita/Orleans.Multitenant#readme) and the inline C# documentation. All public Orleans.Multitenant API's come with full inline documentation.
 
-[Release Notes](https://github.com/Applicita/Orleans.Multitenant/releases/tag/2-1-0)
+[Release Notes](https://github.com/Applicita/Orleans.Multitenant/releases/tag/2-2-8)


### PR DESCRIPTION
- add an optional `getProviderParameters` delegate parameter to support custom grain storage provider ctor parameters
- include example for how to use `getProviderParameters` with the  ADO.NET Orleans storage provider in readme